### PR TITLE
Support enabling enable_check_dependencies at the toolchain level

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -34,7 +34,7 @@ def _run_android_lint(
         enable_checks,
         autofix,
         regenerate,
-        enable_check_dependencies):
+        android_lint_enable_check_dependencies):
     """Constructs the Android Lint actions
 
     Args:
@@ -56,7 +56,7 @@ def _run_android_lint(
         enable_checks: List of additional checks to enable
         autofix: Whether to autofix (This is a no-op feature right now)
         regenerate: Whether to regenerate the baseline files
-        enable_check_dependencies: Enables dependency checking during analysis
+        android_lint_enable_check_dependencies: Enables dependency checking during analysis
     """
     inputs = []
     outputs = [output]
@@ -104,7 +104,7 @@ def _run_android_lint(
     for dep in classpath_deps:
         args.add("--classpath", dep)
     inputs.extend(classpath_deps)
-    if enable_check_dependencies:
+    if android_lint_enable_check_dependencies:
         args.add("--enable-check-dependencies")
 
     # Declare the output file
@@ -210,7 +210,7 @@ def process_android_lint_issues(ctx, regenerate):
         enable_checks = ctx.attr.enable_checks,
         autofix = ctx.attr.autofix,
         regenerate = regenerate,
-        enable_check_dependencies = _utils.get_android_lint_toolchain(ctx).enable_check_dependencies,
+        android_lint_enable_check_dependencies = _utils.get_android_lint_toolchain(ctx).android_lint_enable_check_dependencies,
     )
 
     return struct(

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -33,7 +33,8 @@ def _run_android_lint(
         disable_checks,
         enable_checks,
         autofix,
-        regenerate):
+        regenerate,
+        enable_check_dependencies):
     """Constructs the Android Lint actions
 
     Args:
@@ -55,6 +56,7 @@ def _run_android_lint(
         enable_checks: List of additional checks to enable
         autofix: Whether to autofix (This is a no-op feature right now)
         regenerate: Whether to regenerate the baseline files
+        enable_check_dependencies: Enables dependency checking during analysis
     """
     inputs = []
     outputs = [output]
@@ -102,6 +104,8 @@ def _run_android_lint(
     for dep in classpath_deps:
         args.add("--classpath", dep)
     inputs.extend(classpath_deps)
+    if enable_check_dependencies:
+        args.add("--enable-check-dependencies")
 
     # Declare the output file
     output = ctx.actions.declare_file("{}.xml".format(ctx.label.name))
@@ -206,6 +210,7 @@ def process_android_lint_issues(ctx, regenerate):
         enable_checks = ctx.attr.enable_checks,
         autofix = ctx.attr.autofix,
         regenerate = regenerate,
+        enable_check_dependencies = _utils.get_android_lint_toolchain(ctx).enable_check_dependencies,
     )
 
     return struct(

--- a/src/cli/AndroidLintActionArgs.kt
+++ b/src/cli/AndroidLintActionArgs.kt
@@ -108,6 +108,11 @@ internal class AndroidLintActionArgs(
     help = "",
   )
 
+  val enableCheckDependencies: Boolean by parser.flagging(
+    names = arrayOf("--enable-check-dependencies"),
+    help = "",
+  ).default { false }
+
   companion object {
 
     internal fun parseArgs(args: List<String>): AndroidLintActionArgs {

--- a/src/cli/AndroidLintRunner.kt
+++ b/src/cli/AndroidLintRunner.kt
@@ -131,19 +131,17 @@ internal class AndroidLintRunner {
     // TODO(bencodes) Use reflection to open this so that the lint version
     // can be dynamically set by the toolchain.
     val main = Main()
-    disableDependenciesCheck(main)
+    disableDependenciesCheck(main, actionArgs.enableCheckDependencies)
     return main.run(args.toTypedArray())
   }
 
-  // A reflection hack for forcing lint to not run against transitive dependencies
-  // TODO(bencodes) Allow this to be toggled from the toolchain
-  private fun disableDependenciesCheck(lintMain: Main) {
+  private fun disableDependenciesCheck(lintMain: Main, enableCheckDependencies: Boolean) {
     val mainClass = Class.forName("com.android.tools.lint.Main")
     val lintCliFlagsField = mainClass.getDeclaredField("flags")
     lintCliFlagsField.isAccessible = true
 
     val lintCliFlags = lintCliFlagsField.get(lintMain) as LintCliFlags
-    lintCliFlags.isCheckDependencies = false
+    lintCliFlags.isCheckDependencies = enableCheckDependencies
   }
 
   /**

--- a/tests/src/cli/AndroidLintActionArgsTest.kt
+++ b/tests/src/cli/AndroidLintActionArgsTest.kt
@@ -46,6 +46,7 @@ class AndroidLintActionArgsTest {
         "1.7",
         "--kotlin-language-level",
         "1.8",
+        "--enable-check-dependencies",
       ),
     )
 
@@ -66,5 +67,6 @@ class AndroidLintActionArgsTest {
     assertThat(parseArgs.compileSdkVersion).isEqualTo("1.6")
     assertThat(parseArgs.javaLanguageLevel).isEqualTo("1.7")
     assertThat(parseArgs.kotlinLanguageLevel).isEqualTo("1.8")
+    assertThat(parseArgs.enableCheckDependencies).isTrue()
   }
 }

--- a/toolchains/toolchain.bzl
+++ b/toolchains/toolchain.bzl
@@ -1,6 +1,13 @@
 """Android Lint Toolchain."""
 
 _ATTRS = dict(
+    enable_check_dependencies = attr.bool(
+        default = False,
+        doc = """Enables the dependency analysis features within lint. Warning: This feature is extremely
+        expensive and will slow down Lint. It's recommended that you leave this feature disabled unless it's
+        explicitly required.
+        """,
+    ),
     compile_sdk_version = attr.string(
         default = "34",
         doc = "The Android SDK version to compile against.",

--- a/toolchains/toolchain.bzl
+++ b/toolchains/toolchain.bzl
@@ -1,7 +1,7 @@
 """Android Lint Toolchain."""
 
 _ATTRS = dict(
-    enable_check_dependencies = attr.bool(
+    android_lint_enable_check_dependencies = attr.bool(
         default = False,
         doc = """Enables the dependency analysis features within lint. Warning: This feature is extremely
         expensive and will slow down Lint. It's recommended that you leave this feature disabled unless it's


### PR DESCRIPTION
Pulling `enable_check_dependencies` support up into the toolchain.