### PR TITLE
Pull android_lint_skip_bytecode_verifier up to the toolchain

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -34,7 +34,8 @@ def _run_android_lint(
         enable_checks,
         autofix,
         regenerate,
-        android_lint_enable_check_dependencies):
+        android_lint_enable_check_dependencies,
+        android_lint_skip_bytecode_verifier):
     """Constructs the Android Lint actions
 
     Args:
@@ -57,6 +58,7 @@ def _run_android_lint(
         autofix: Whether to autofix (This is a no-op feature right now)
         regenerate: Whether to regenerate the baseline files
         android_lint_enable_check_dependencies: Enables dependency checking during analysis
+        android_lint_skip_bytecode_verifier: Disables bytecode verification
     """
     inputs = []
     outputs = [output]
@@ -127,7 +129,7 @@ def _run_android_lint(
         },
         env = {
             # https://googlesamples.github.io/android-custom-lint-rules/usage/variables.md.html
-            "ANDROID_LINT_SKIP_BYTECODE_VERIFIER": "true",
+            "ANDROID_LINT_SKIP_BYTECODE_VERIFIER": ("true" if android_lint_skip_bytecode_verifier else "false"),
         },
     )
 
@@ -211,6 +213,7 @@ def process_android_lint_issues(ctx, regenerate):
         autofix = ctx.attr.autofix,
         regenerate = regenerate,
         android_lint_enable_check_dependencies = _utils.get_android_lint_toolchain(ctx).android_lint_enable_check_dependencies,
+        android_lint_skip_bytecode_verifier = _utils.get_android_lint_toolchain(ctx).android_lint_skip_bytecode_verifier,
     )
 
     return struct(

--- a/toolchains/toolchain.bzl
+++ b/toolchains/toolchain.bzl
@@ -8,6 +8,15 @@ _ATTRS = dict(
         explicitly required.
         """,
     ),
+    android_lint_skip_bytecode_verifier = attr.bool(
+        default = False,
+        doc = """Enables bytecode verification inside of Android Lint. Jars that fail bytecode verification
+        may be quietly excluded.
+
+        Enabling this may be necessary if Lint rule jars
+        are being included that are compiled using a newer JDK.
+        """,
+    ),
     compile_sdk_version = attr.string(
         default = "34",
         doc = "The Android SDK version to compile against.",


### PR DESCRIPTION
Pulls `android_lint_skip_bytecode_verifier` up to the toolchain so that it can be toggled.