### PR TITLE
Flip supports-multiplex-workers back on

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -125,6 +125,7 @@ def _run_android_lint(
         toolchain = _ANDROID_LINT_TOOLCHAIN_TYPE,
         execution_requirements = {
             "supports-workers": "1",
+            "supports-multiplex-workers": "1",
             "requires-worker-protocol": "json",
         },
         env = {


### PR DESCRIPTION
I disabled this while re-organizing everything. Enabling it again by default.