### PR TITLE
Decouple the rule set from the lint cli tool

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -17,6 +17,7 @@ load(
 
 def _run_android_lint(
         ctx,
+        android_lint,
         module_name,
         output,
         srcs,
@@ -40,6 +41,7 @@ def _run_android_lint(
 
     Args:
         ctx: The target context
+        android_lint: The Android Lint binary to use
         module_name: The name of the module
         output: The output file
         srcs: The source files
@@ -67,6 +69,8 @@ def _run_android_lint(
     args.set_param_file_format("multiline")
     args.use_param_file("@%s", use_always = True)
 
+    args.add("--android-lint-cli-tool", android_lint)
+    inputs.append(android_lint)
     args.add("--label", "{}".format(module_name))
     if compile_sdk_version:
         args.add("--compile-sdk-version", compile_sdk_version)
@@ -195,6 +199,7 @@ def process_android_lint_issues(ctx, regenerate):
     output = ctx.actions.declare_file("{}.xml".format(ctx.label.name))
     _run_android_lint(
         ctx,
+        android_lint = _utils.only(_utils.list_or_depset_to_list(_utils.get_android_lint_toolchain(ctx).android_lint.files)),
         module_name = _get_module_name(ctx),
         output = output,
         srcs = ctx.files.srcs,

--- a/src/cli/AndroidLintActionArgs.kt
+++ b/src/cli/AndroidLintActionArgs.kt
@@ -15,6 +15,12 @@ internal class AndroidLintActionArgs(
     Paths.get(this)
   }
 
+  val androidLintCliTool: Path by parser.storing(
+    names = arrayOf("--android-lint-cli-tool"),
+    help = "",
+    transform = argsParserPathTransformer,
+  )
+
   val label: String by parser.storing(
     names = arrayOf("--label"),
     help = "",

--- a/src/cli/AndroidLintRunner.kt
+++ b/src/cli/AndroidLintRunner.kt
@@ -58,8 +58,9 @@ internal class AndroidLintRunner {
     )
 
     // Run Android Lint
+    val invoker = AndroidLintCliInvoker.createUsingJars(jars = arrayOf(args.androidLintCliTool))
     val exitCode = invokeAndroidLintCLI(
-      invoker = AndroidLintCliInvoker(classLoader = this.javaClass.classLoader),
+      invoker = invoker,
       actionArgs = args,
       projectFilePath = projectFile,
       baselineFilePath = baselineFile,
@@ -72,17 +73,6 @@ internal class AndroidLintRunner {
       .run { AndroidLintBaselineSanitizer.sanitize(this) }
     args.output.writeText(sanitizedContent)
 
-    /*
-     * Exit Status:
-     * 0   ->   Success.
-     * 1   ->   Lint errors detected.
-     * 2   ->   Lint usage.
-     * 3   ->   Cannot clobber existing file.
-     * 4   ->   Lint help.
-     * 5   ->   Invalid command-line argument.
-     * 6   ->   Created baseline file.
-     * 100 ->   Internal continue.
-     */
     return when (exitCode) {
       AndroidLintCliInvoker.ERRNO_SUCCESS,
       AndroidLintCliInvoker.ERRNO_CREATED_BASELINE,

--- a/src/cli/BUILD
+++ b/src/cli/BUILD
@@ -15,10 +15,6 @@ kt_jvm_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/worker",
-        "@rules_android_lint_deps//:com_android_tools_lint_lint",
-        "@rules_android_lint_deps//:com_android_tools_lint_lint_api",
-        "@rules_android_lint_deps//:com_android_tools_lint_lint_checks",
-        "@rules_android_lint_deps//:com_android_tools_lint_lint_model",
         "@rules_android_lint_deps//:com_xenomachina_kotlin_argparser",
     ],
 )

--- a/tests/src/cli/AndroidLintActionArgsTest.kt
+++ b/tests/src/cli/AndroidLintActionArgsTest.kt
@@ -15,6 +15,8 @@ class AndroidLintActionArgsTest {
       args = listOf(
         "--label",
         "test",
+        "--android-lint-cli-tool",
+        "path/to/cli.jar",
         "--src",
         "path/to/Foo.kt",
         "--output",

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
+java_binary(
+    name = "com_android_tools_lint_lint",
+    main_class = "com.android.tools.lint.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@rules_android_lint_deps//:com_android_tools_lint_lint",
+        "@rules_android_lint_deps//:com_android_tools_lint_lint_api",
+        "@rules_android_lint_deps//:com_android_tools_lint_lint_checks",
+        "@rules_android_lint_deps//:com_android_tools_lint_lint_model",
+    ],
+)

--- a/toolchains/toolchain.bzl
+++ b/toolchains/toolchain.bzl
@@ -1,6 +1,12 @@
 """Android Lint Toolchain."""
 
 _ATTRS = dict(
+    android_lint = attr.label(
+        default = Label("//third_party:com_android_tools_lint_lint_deploy.jar"),
+        doc = "The Android Lint deploy jar",
+        allow_single_file = True,
+        cfg = "exec",
+    ),
     android_lint_enable_check_dependencies = attr.bool(
         default = False,
         doc = """Enables the dependency analysis features within lint. Warning: This feature is extremely


### PR DESCRIPTION
Decouples lint from the Android Lint CLI tool allowing the version to be dynamically set at the toolchain level.

The new toolchain field current expects a single deploy jar containing the complete classpath.