### PR TITLE
Remove experimental status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This repository contains Bazel rules for running Android Lint.
 
-These rules are currently in alpha and the APIs are subject to change.
-
 ## Features
 
 - Running Android Lint on Android, Kotlin, and JVM targets


### PR DESCRIPTION
Removing the experimental status from the README since a few companies are using these rules in large production environments already.