### PR TITLE
Adding Android Home support

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -118,6 +118,12 @@ def _run_android_lint(
     args.add("--output", output)
     outputs.append(output)
 
+    toolchain = _utils.get_android_lint_toolchain(ctx)
+    if toolchain.android_home != None:
+        args.add("--android-home", toolchain.android_home.label.workspace_root)
+    else:
+        print("WARNING: No android-home has been specified! Some linters will be omitted!")
+
     ctx.actions.run(
         mnemonic = "AndroidLint",
         inputs = inputs,

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -121,8 +121,6 @@ def _run_android_lint(
     toolchain = _utils.get_android_lint_toolchain(ctx)
     if toolchain.android_home != None:
         args.add("--android-home", toolchain.android_home.label.workspace_root)
-    else:
-        print("WARNING: No android-home has been specified! Some linters will be omitted!")
 
     ctx.actions.run(
         mnemonic = "AndroidLint",

--- a/src/cli/AndroidLintActionArgs.kt
+++ b/src/cli/AndroidLintActionArgs.kt
@@ -26,6 +26,11 @@ internal class AndroidLintActionArgs(
     help = "",
   )
 
+  val androidHome: String? by parser.storing(
+    names = arrayOf("--android-home"),
+    help = "The relative location of Android home",
+  ).default { null }
+
   val srcs: List<Path> by parser.adding(
     names = arrayOf("--src"),
     help = "",

--- a/src/cli/AndroidLintRunner.kt
+++ b/src/cli/AndroidLintRunner.kt
@@ -2,9 +2,11 @@ package com.rules.android.lint.cli
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.isRegularFile
@@ -129,6 +131,13 @@ internal class AndroidLintRunner {
     if (actionArgs.disableChecks.isNotEmpty()) {
       args.add("--disable")
       args.add(actionArgs.disableChecks.joinToString(","))
+    }
+
+    if (actionArgs.androidHome?.isNotEmpty() != null) {
+      var androidHomePath =
+        Paths.get(System.getenv("PWD"), actionArgs.androidHome).absolutePathString()
+      args.add("--sdk-home")
+      args.add(androidHomePath)
     }
 
     invoker.setCheckDependencies(actionArgs.enableCheckDependencies)

--- a/toolchains/toolchain.bzl
+++ b/toolchains/toolchain.bzl
@@ -40,6 +40,10 @@ _ATTRS = dict(
         allow_single_file = True,
         cfg = "exec",
     ),
+    android_home = attr.label(
+        mandatory = False,
+        doc = "The target that represents where the ANDROID_HOME is located.",
+    ),
 )
 
 def _impl(ctx):


### PR DESCRIPTION
Directly inject android_home into lint and reconstructs the absolute path without resorting to using the ANDROID_HOME environment variable outside of Bazel.

This is opposed to [Grab's approach.](https://github.com/grab/grab-bazel-common/blob/02735d57ab96392d9b590398218a6be3e1f[…]3813f/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt](https://github.com/grab/grab-bazel-common/blob/02735d57ab96392d9b590398218a6be3e1f3813f/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt#L213C28-L213C40) that constructs the field from environment variable.

How to Use:

    android_lint_test(
        **android_home = "@androidsdk//:sdk",**
    )
    
 This way, we keep the sdk in parity with whatever we have specified in WORKSPACE.