### PR TITLE
Bug with Android Manifest being added from dependent libraries

### DIFF
--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -107,6 +107,8 @@ def _run_android_lint(
     for check in enable_checks:
         args.add("--enable-check", check)
     for dep in _utils.list_or_depset_to_list(deps):
+        if not dep.path.endswith(".aar") and not dep.path.endswith(".jar"):
+            continue
         args.add("--classpath", dep)
         inputs.append(dep)
     if android_lint_enable_check_dependencies:


### PR DESCRIPTION
We are running into a bug where if other Android libraries are being added, we will fail compilation because other AndroidManifest.xml are being added to the compilation.

Since this classpath check is only for aar and jar files, we want to filter out files that don't conform.