### PR TITLE
Fixing Bug With Android Folder in Runner

### DIFF
--- a/src/cli/AndroidLintRunner.kt
+++ b/src/cli/AndroidLintRunner.kt
@@ -58,13 +58,15 @@ internal class AndroidLintRunner {
     )
 
     // Run Android Lint
+    val androidCacheFolder = workingDirectory.resolve("android-cache")
+    Files.createDirectory(androidCacheFolder)
     val invoker = AndroidLintCliInvoker.createUsingJars(jars = arrayOf(args.androidLintCliTool))
     val exitCode = invokeAndroidLintCLI(
       invoker = invoker,
       actionArgs = args,
       projectFilePath = projectFile,
       baselineFilePath = baselineFile,
-      cacheDirectoryPath = workingDirectory.resolve("android-cache"),
+      cacheDirectoryPath = androidCacheFolder,
     )
 
     // Pure hacks to strip the relative paths and exec roots out of the file


### PR DESCRIPTION
Before running the AndroidLintCLI, there may be times in new invocations where you are not guaranteed to have the android-cache folder.

This fix will guarantee the folder exists before writing to it.