### PR TITLE
[CI] Bump Bazel versions to 6.5.0 and 7.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         bzlmod: [true]
-        bazel_version: ["6.4.0", "7.0.0"]
+        bazel_version: ["6.5.0", "7.1.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"
@@ -46,7 +46,7 @@ jobs:
         bzlmod: [true]
         directory: [examples/simple-android]
         strategy: [local, worker]
-        bazel_version: ["7.0.0"]
+        bazel_version: ["7.1.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"


### PR DESCRIPTION
Pulling in the latest stable releases for both 6.x and 7.x.