### PR TITLE
Pass `client-id` to lint cli

### DIFF
--- a/src/cli/AndroidLintRunner.kt
+++ b/src/cli/AndroidLintRunner.kt
@@ -111,6 +111,7 @@ internal class AndroidLintRunner {
       "--update-baseline",
       "--cache-dir",
       cacheDirectoryPath.pathString,
+      "--client-id", "cli",
     )
     if (actionArgs.warningsAsErrors) {
       args.add("-Werror")


### PR DESCRIPTION
Lint implementation can change behavior based on passed `client-id`s. Among various recognized ids like `test`, `gradle`, `studio`, cli is the most appropriate one and this PR passes it to lint cli.

Observed internally that certain [detectors](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-api/src/main/java/com/android/tools/lint/detector/api/LintFix.kt;l=1786;drc=042516205eef87810ffe9f6d51ba40b1edbb15b0) require client id to be set