### PR TITLE
Add MODULE.bazel.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bazel-*
 .idea/
 .ijwb/
 .aswb
+MODULE.bazel.lock


### PR DESCRIPTION
Adding `MODULE.bazel.lock` to the gitignore so that it doesn't get accidentally checked in.