### PR TITLE
[Bzlmod] Remove enable_bzlmod now that it's enabled by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-common --enable_bzlmod
 common --experimental_google_legacy_api
 
 try-import %workspace%/.bazelrc.user


### PR DESCRIPTION
This is enabled by default in 7.1.1

https://github.com/bazelbuild/bazel/blob/release-7.1.1/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java#L197-L206