### PR TITLE
Load rules_android and providers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 common --experimental_google_legacy_api
+common --check_visibility=false
 
 try-import %workspace%/.bazelrc.user

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "rules_android", version = "0.5.0")
 bazel_dep(name = "rules_java", version = "7.0.6")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_kotlin", version = "1.9.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_android", version = "6.0.0")
+bazel_dep(name = "rules_android", version = "0.6.0")
 bazel_dep(name = "rules_java", version = "7.0.6")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_kotlin", version = "1.9.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "rules_android", version = "0.6.0")
 bazel_dep(name = "rules_java", version = "7.0.6")
-bazel_dep(name = "rules_jvm_external", version = "5.3")
+bazel_dep(name = "rules_jvm_external", version = "6.6")
 bazel_dep(name = "rules_kotlin", version = "1.9.5")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.8")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_android", version = "0.5.0")
+bazel_dep(name = "rules_android", version = "6.0.0")
 bazel_dep(name = "rules_java", version = "7.0.6")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_kotlin", version = "1.9.5")

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,6 +7,8 @@ Android Lint rules
 ## android_lint
 
 <pre>
+load("@rules_android_lint//rules:defs.bzl", "android_lint")
+
 android_lint(<a href="#android_lint-name">name</a>, <a href="#android_lint-deps">deps</a>, <a href="#android_lint-srcs">srcs</a>, <a href="#android_lint-android_lint_config">android_lint_config</a>, <a href="#android_lint-autofix">autofix</a>, <a href="#android_lint-custom_rules">custom_rules</a>, <a href="#android_lint-disable_checks">disable_checks</a>,
              <a href="#android_lint-enable_checks">enable_checks</a>, <a href="#android_lint-is_test_sources">is_test_sources</a>, <a href="#android_lint-lib">lib</a>, <a href="#android_lint-manifest">manifest</a>, <a href="#android_lint-resource_files">resource_files</a>, <a href="#android_lint-warnings_as_errors">warnings_as_errors</a>)
 </pre>
@@ -38,6 +40,8 @@ android_lint(<a href="#android_lint-name">name</a>, <a href="#android_lint-deps"
 ## android_lint_test
 
 <pre>
+load("@rules_android_lint//rules:defs.bzl", "android_lint_test")
+
 android_lint_test(<a href="#android_lint_test-name">name</a>, <a href="#android_lint_test-deps">deps</a>, <a href="#android_lint_test-srcs">srcs</a>, <a href="#android_lint_test-android_lint_config">android_lint_config</a>, <a href="#android_lint_test-autofix">autofix</a>, <a href="#android_lint_test-baseline">baseline</a>, <a href="#android_lint_test-custom_rules">custom_rules</a>,
                   <a href="#android_lint_test-disable_checks">disable_checks</a>, <a href="#android_lint_test-enable_checks">enable_checks</a>, <a href="#android_lint_test-is_test_sources">is_test_sources</a>, <a href="#android_lint_test-lib">lib</a>, <a href="#android_lint_test-manifest">manifest</a>, <a href="#android_lint_test-resource_files">resource_files</a>,
                   <a href="#android_lint_test-warnings_as_errors">warnings_as_errors</a>)
@@ -71,13 +75,14 @@ android_lint_test(<a href="#android_lint_test-name">name</a>, <a href="#android_
 ## AndroidLintResultsInfo
 
 <pre>
+load("@rules_android_lint//rules:defs.bzl", "AndroidLintResultsInfo")
+
 AndroidLintResultsInfo(<a href="#AndroidLintResultsInfo-output">output</a>)
 </pre>
 
 Info needed to evaluate lint results
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -72,6 +72,7 @@ bzl_library(
     deps = [
         ":collect_aar_outputs_aspect",
         "@bazel_skylib//lib:dicts",
+        "@rules_android//providers:providers_bzl",
     ],
 )
 

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -2,6 +2,15 @@
 """
 
 load(
+    "@rules_android//providers:providers.bzl",
+    "AndroidLibraryAarInfo",
+    "AndroidLibraryResourceClassJarProvider",
+)
+load(
+    "@rules_java//java:defs.bzl",
+    "JavaInfo",
+)
+load(
     ":collect_aar_outputs_aspect.bzl",
     _AndroidLintAARInfo = "AndroidLintAARInfo",
 )
@@ -13,15 +22,6 @@ load(
     ":utils.bzl",
     _ANDROID_LINT_TOOLCHAIN_TYPE = "ANDROID_LINT_TOOLCHAIN_TYPE",
     _utils = "utils",
-)
-load(
-    "@rules_android//providers:providers.bzl",
-    "AndroidLibraryResourceClassJarProvider",
-    "AndroidLibraryAarInfo"
-)
-load(
-    "@rules_java//java:defs.bzl",
-    "JavaInfo"
 )
 
 def _run_android_lint(

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -14,6 +14,11 @@ load(
     _ANDROID_LINT_TOOLCHAIN_TYPE = "ANDROID_LINT_TOOLCHAIN_TYPE",
     _utils = "utils",
 )
+load(
+    "@rules_android//providers:providers.bzl",
+    "AndroidLibraryResourceClassJarProvider",
+    "AndroidLibraryAarInfo"
+)
 
 def _run_android_lint(
         ctx,

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -19,6 +19,10 @@ load(
     "AndroidLibraryResourceClassJarProvider",
     "AndroidLibraryAarInfo"
 )
+load(
+    "@rules_java//java:defs.bzl",
+    "JavaInfo"
+)
 
 def _run_android_lint(
         ctx,

--- a/rules/impl.bzl
+++ b/rules/impl.bzl
@@ -1,7 +1,6 @@
 """Rule implementation for Android Lint
 """
 
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "@rules_android//providers:providers.bzl",
     "AndroidLibraryAarInfo",


### PR DESCRIPTION
Running `bazel build :lint` with bazel version 8 and was able to run successfully after adding `rules_android` bazel dep.