### PR TITLE
Drop Bazel 6.x from ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         bzlmod: [true]
-        bazel_version: ["7.1.1"]
+        bazel_version: ["7.4.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         bzlmod: [true]
-        bazel_version: ["6.5.0", "7.1.1"]
+        bazel_version: ["7.1.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         bzlmod: [true]
         directory: [examples/simple-android]
         strategy: [local, worker]
-        bazel_version: ["7.1.1"]
+        bazel_version: ["7.4.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"


### PR DESCRIPTION
This is no longer supported moving forward.