### PR TITLE
Update ci.yaml to use Bazel 8.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         bzlmod: [true]
-        bazel_version: ["7.4.1", "8.0.0"]
+        bazel_version: ["7.4.1", "8.0.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"
@@ -47,7 +47,7 @@ jobs:
         bzlmod: [true]
         directory: [examples/simple-android]
         strategy: [local, worker]
-        bazel_version: ["7.4.1", "8.0.0"]
+        bazel_version: ["7.4.1", "8.0.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout the sources"


### PR DESCRIPTION
Bumping the Bazel version again after this landed https://github.com/Bencodes/rules_android_lint/pull/71